### PR TITLE
set font stack #392

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -13,7 +13,7 @@
 
 html, button, input, select, textarea,
 .pure-g [class *= "pure-u"] {
-    font-family: sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
     font-weight: 100;
     letter-spacing: 0.01em;
 }


### PR DESCRIPTION
This is a follow-up from issue #392.

I noticed that the site is perfectly readable from Firefox on Windows, and that the issue is really about the font weight when viewed from Firefox on Ubuntu:
https://imgur.com/a/fuCsX

It looks like there's no font stack supplied aside from 'sans-serif', which falls back to the default system font. I'm not sure if you folks want to set a global font stack set for a case like this, but I submitted a PR anyways.